### PR TITLE
refactor: parser and ast

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ fn main() {
     }
 
     // We will now pass the tokens to the parser
-    let ast = parser::parser::parse(tokens);
+    let ast = parser::parser::parse_prog(tokens);
     // Print the AST if the option is enabled
     if print_ast {
         println!("{:?}", ast);

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -2,182 +2,128 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::fmt::Result;
 
-pub struct NodeProgram {
-    functions: Vec<NodeFunc>,
+pub struct NodeProg {
+    pub functions: Vec<NodeFunc>,
 }
 
-impl Debug for NodeProgram {
+impl Debug for NodeProg {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        let mut res = "<Program ".to_string();
-        for (idx, function) in self.functions.iter().enumerate() {
-            res.push_str(format!("function_{}={:?} ", idx, function).as_str());
+        write!(f, "<Prog")?;
+        for (idx, func) in self.functions.iter().enumerate() {
+            write!(f, " func_{}={:?}", idx, func)?;
         }
-        write!(f, "{}>", res[..res.len() - 1].to_string())
-    }
-}
-
-impl NodeProgram {
-    pub fn new(functions: Vec<NodeFunc>) -> NodeProgram {
-        NodeProgram { functions }
+        write!(f, ">")
     }
 }
 
 pub struct NodeFunc {
-    identifier: NodeIdent,
-    // parameters: Vec<NodeParameter>,
-    return_type: NodeType,
-    body: NodeBlock,
+    pub ident: NodeIdent,
+    pub r_type: NodeType,
+    pub block: NodeBlock,
 }
 
 impl Debug for NodeFunc {
     fn fmt(&self, f: &mut Formatter) -> Result {
         write!(
             f,
-            "<Function identifier={:?} rtype={:?} body={:?}>",
-            self.identifier, self.return_type, self.body
+            "<Func {:?} r_type={:?} block={:?}>",
+            self.ident, self.r_type, self.block
         )
     }
 }
 
-impl NodeFunc {
-    pub fn new(identifier: NodeIdent, return_type: NodeType, body: NodeBlock) -> NodeFunc {
-        NodeFunc {
-            identifier,
-            return_type,
-            body,
-        }
-    }
-}
-
-pub struct NodeType {
-    name: String,
-}
-
-impl Debug for NodeType {
-    fn fmt(&self, f: &mut Formatter) -> Result {
-        write!(f, "<Type name={:?}>", self.name)
-    }
-}
-
-impl NodeType {
-    pub fn new(name: String) -> NodeType {
-        NodeType { name }
-    }
-
-    pub fn get_name(&self) -> String {
-        self.name.clone()
-    }
-}
-
 pub struct NodeBlock {
-    statements: Vec<NodeStatement>,
+    pub stmts: Vec<NodeStmt>,
 }
 
 impl Debug for NodeBlock {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        let mut res = "<Block ".to_string();
-        for (idx, statement) in self.statements.iter().enumerate() {
-            res.push_str(format!("statement_{}={:?} ", idx, statement).as_str());
+        write!(f, "<Block")?;
+        for (idx, stmt) in self.stmts.iter().enumerate() {
+            write!(f, " stmt_{}={:?}", idx, stmt)?;
         }
-        write!(f, "{}>", res[..res.len() - 1].to_string())
+        write!(f, ">")
     }
 }
 
-impl NodeBlock {
-    pub fn new(statements: Vec<NodeStatement>) -> NodeBlock {
-        NodeBlock { statements }
-    }
+pub enum NodeStmt {
+    Return(NodeExpr),
 }
 
-pub enum NodeStatement {
-    Return(NodeReturn),
-}
-
-impl Debug for NodeStatement {
+impl Debug for NodeStmt {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match self {
-            NodeStatement::Return(r) => write!(f, "{:?}", r),
+            NodeStmt::Return(expr) => write!(f, "<Return expr={:?}>", expr),
         }
-    }
-}
-
-pub struct NodeReturn {
-    expression: NodeExpr,
-}
-
-impl Debug for NodeReturn {
-    fn fmt(&self, f: &mut Formatter) -> Result {
-        write!(f, "<Return expression={:?}>", self.expression)
-    }
-}
-
-impl NodeReturn {
-    pub fn new(expression: NodeExpr) -> NodeReturn {
-        NodeReturn { expression }
     }
 }
 
 pub enum NodeExpr {
-    Id(NodeIdent),
     Literal(NodeLiteral),
+    Ident(NodeIdent),
 }
 
 impl Debug for NodeExpr {
     fn fmt(&self, f: &mut Formatter) -> Result {
         match self {
-            NodeExpr::Id(i) => write!(f, "{:?}", i),
-            NodeExpr::Literal(l) => write!(f, "{:?}", l),
+            NodeExpr::Literal(literal) => write!(f, "<Literal {:?}>", literal),
+            NodeExpr::Ident(ident) => write!(f, "<Ident {:?}>", ident),
+        }
+    }
+}
+
+pub enum NodeLiteral {
+    IntLit(i64),
+}
+
+impl Debug for NodeLiteral {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        match self {
+            NodeLiteral::IntLit(x) => write!(f, "type=int value={}", x),
         }
     }
 }
 
 pub struct NodeIdent {
-    name: String,
-    _metatype: String,
+    pub name: String,
 }
 
 impl Debug for NodeIdent {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        write!(f, "<Identifier name={:?}>", self.name)
+        write!(f, "name={}", self.name)
     }
 }
 
-impl NodeIdent {
-    pub fn new(name: String, possible_type: Option<&String>) -> NodeIdent {
-        NodeIdent {
-            name,
-            _metatype: match possible_type {
-                Some(t) => t.clone(),
-                None => "void".to_string(),
-            },
+pub struct NodeType {
+    pub meta: TypeMeta,
+}
+
+impl Debug for NodeType {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        write!(f, "<Type meta={:?}>", self.meta)
+    }
+}
+
+pub enum TypeMeta {
+    Primitive(PrimitiveType),
+}
+
+impl Debug for TypeMeta {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        match self {
+            TypeMeta::Primitive(primitive_type) => write!(f, "{:?}", primitive_type),
         }
     }
-
-    pub fn set_metatype(&mut self, metatype: String) {
-        self._metatype = metatype;
-    }
-
-    pub fn get_name(&self) -> String {
-        self.name.clone()
-    }
 }
 
-pub struct NodeLiteral {
-    value: String,
-    _metatype: String,
+pub enum PrimitiveType {
+    Int,
 }
 
-impl Debug for NodeLiteral {
+impl Debug for PrimitiveType {
     fn fmt(&self, f: &mut Formatter) -> Result {
-        write!(f, "<Literal value={:?}>", self.value)
-    }
-}
-
-impl NodeLiteral {
-    pub fn new(value: String) -> NodeLiteral {
-        NodeLiteral {
-            value,
-            _metatype: "int".to_string(),
+        match self {
+            PrimitiveType::Int => write!(f, "int"),
         }
     }
 }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1,160 +1,130 @@
-use std::collections::HashMap;
 use std::iter::Peekable;
 use std::slice::Iter;
 
 use super::super::lexer::tokens::Token;
 use super::super::lexer::tokens::TokenType;
-use super::ast::NodeBlock;
-use super::ast::NodeExpr;
-use super::ast::NodeFunc;
-use super::ast::NodeIdent;
-use super::ast::NodeLiteral;
-use super::ast::NodeProgram;
-use super::ast::NodeReturn;
-use super::ast::NodeStatement;
-use super::ast::NodeType;
+use super::ast::*;
 
-pub fn parse(tokens: Vec<Token>) -> NodeProgram {
+pub fn parse_prog(tokens: Vec<Token>) -> NodeProg {
     let mut token_iter = tokens.iter().peekable();
-    let mut functions = vec![];
-    let mut vars: HashMap<String, String> = HashMap::new();
-
+    let mut functions: Vec<NodeFunc> = Vec::new();
     while let Some(token) = token_iter.peek() {
         if token.token_type == TokenType::EOF {
             break;
         }
-        let function = parse_function(&mut token_iter, &mut vars);
-        functions.push(function);
+        functions.push(parse_func(&mut token_iter));
     }
-
-    NodeProgram::new(functions)
+    NodeProg { functions }
 }
 
-fn parse_function(
-    token_iter: &mut Peekable<Iter<Token>>,
-    vars: &mut HashMap<String, String>,
-) -> NodeFunc {
-    let token = token_iter.peek().unwrap();
-    let ident_name = token.value.clone();
-
-    if vars.contains_key(ident_name.as_str()) {
-        panic!("Function {} already defined", ident_name);
-    }
-
-    let mut identifier = parse_ident(token_iter, vars);
+fn parse_func(token_iter: &mut Peekable<Iter<Token>>) -> NodeFunc {
+    let ident = parse_ident(token_iter);
     parse_symbol(token_iter, TokenType::LP);
     parse_symbol(token_iter, TokenType::RP);
     parse_symbol(token_iter, TokenType::Colon);
-    let return_type = parse_type(token_iter);
-    let func_type = format!("() -> {}", return_type.get_name());
-    vars.insert(identifier.get_name(), func_type.clone());
-    identifier.set_metatype(func_type);
+    let r_type = parse_type(token_iter);
     parse_symbol(token_iter, TokenType::Assign);
-    let body = parse_block(token_iter, vars);
-    NodeFunc::new(identifier, return_type, body)
+    let block = parse_block(token_iter);
+    NodeFunc {
+        ident,
+        r_type,
+        block,
+    }
 }
 
-fn parse_ident(
-    token_iter: &mut Peekable<Iter<Token>>,
-    vars: &mut HashMap<String, String>,
-) -> NodeIdent {
+fn parse_ident(token_iter: &mut Peekable<Iter<Token>>) -> NodeIdent {
     let token = token_iter.next().unwrap();
-    let value = token.value.clone();
-    let possible_type = vars.get(value.as_str());
     if token.token_type != TokenType::Id {
-        panic!("{}", panic_str(token, TokenType::Id));
+        panic!(
+            "Expected an identifier, got {:?} instead.",
+            token.token_type
+        );
     }
-    NodeIdent::new(token.value.clone(), possible_type)
+    NodeIdent {
+        name: token.value.clone(),
+    }
+}
+
+fn parse_symbol(token_iter: &mut Peekable<Iter<Token>>, symbol: TokenType) {
+    let token = token_iter.next().unwrap();
+    if token.token_type != symbol {
+        panic!(
+            "Expected the symbol {:?}, got {:?} instead.",
+            symbol, token.token_type
+        );
+    }
 }
 
 fn parse_type(token_iter: &mut Peekable<Iter<Token>>) -> NodeType {
     let token = token_iter.next().unwrap();
-    // TODO: I will need to figure out how to handle types ...
-    if token.token_type != TokenType::Int {
-        panic!("{}", panic_str(token, TokenType::Int));
-    }
-    NodeType::new(token.value.clone())
+    let meta = match token.token_type {
+        TokenType::Int => TypeMeta::Primitive(PrimitiveType::Int),
+        _ => panic!("Expected a known type, got {:?} instead.", token.token_type),
+    };
+    NodeType { meta }
 }
 
-fn parse_block(
-    token_iter: &mut Peekable<Iter<Token>>,
-    vars: &mut HashMap<String, String>,
-) -> NodeBlock {
+fn parse_block(token_iter: &mut Peekable<Iter<Token>>) -> NodeBlock {
+    let mut stmts: Vec<NodeStmt> = Vec::new();
     parse_symbol(token_iter, TokenType::LB);
-    let mut statements = vec![];
-
     while let Some(token) = token_iter.peek() {
         if token.token_type == TokenType::RB {
             break;
         }
-        let statement = parse_statement(token_iter, vars);
-        statements.push(statement);
+        stmts.push(parse_stmt(token_iter));
     }
-
     parse_symbol(token_iter, TokenType::RB);
-    NodeBlock::new(statements)
+    NodeBlock { stmts }
 }
 
-fn parse_statement(
-    token_iter: &mut Peekable<Iter<Token>>,
-    vars: &mut HashMap<String, String>,
-) -> NodeStatement {
-    let next_token = token_iter.peek().unwrap();
-    if next_token.token_type == TokenType::Ret {
-        let statement = NodeStatement::Return(parse_return(token_iter, vars));
-        parse_symbol(token_iter, TokenType::Semi);
-        return statement;
+fn parse_stmt(token_iter: &mut Peekable<Iter<Token>>) -> NodeStmt {
+    let stmt: NodeStmt;
+    match token_iter.peek() {
+        Some(token) => match token.token_type {
+            TokenType::Ret => stmt = parse_return_stmt(token_iter),
+            _ => panic!(
+                "Expected the start of a statement, got {:?} instead.",
+                token.token_type
+            ),
+        },
+        None => panic!("Unexpected end of file."),
     }
-    panic!(
-        "Unexpected start of statement:\n\tLine: {}, Col: {}\n\t{:?}",
-        next_token.line, next_token.column, next_token.value
-    );
+    parse_symbol(token_iter, TokenType::Semi);
+    stmt
 }
 
-fn parse_return(
-    token_iter: &mut Peekable<Iter<Token>>,
-    vars: &mut HashMap<String, String>,
-) -> NodeReturn {
+fn parse_return_stmt(token_iter: &mut Peekable<Iter<Token>>) -> NodeStmt {
     parse_symbol(token_iter, TokenType::Ret);
-    let expr = parse_expression(token_iter, vars);
-    NodeReturn::new(expr)
+    let expr = parse_expr(token_iter);
+    NodeStmt::Return(expr)
 }
 
-fn parse_expression(
-    token_iter: &mut Peekable<Iter<Token>>,
-    vars: &mut HashMap<String, String>,
-) -> NodeExpr {
-    let mut peeker = token_iter.clone();
-    let token = peeker.next().unwrap();
-    // TODO: This will need to change once other types are supported
-    if token.token_type == TokenType::IntLit {
-        return NodeExpr::Literal(parse_literal(token_iter));
-    } else if token.token_type == TokenType::Id {
-        return NodeExpr::Id(parse_ident(token_iter, vars));
-    } else {
-        panic!("{}", panic_str(token, TokenType::IntLit));
+fn parse_expr(token_iter: &mut Peekable<Iter<Token>>) -> NodeExpr {
+    match token_iter.peek() {
+        Some(token) => match token.token_type {
+            TokenType::IntLit => parse_literal_expression(token_iter),
+            TokenType::Id => parse_ident_expression(token_iter),
+            _ => panic!(
+                "Expected the start of an expression, got {:?} instead.",
+                token.token_type
+            ),
+        },
+        None => panic!("Unexpected end of file."),
     }
 }
 
-fn parse_literal(token_iter: &mut Peekable<Iter<Token>>) -> NodeLiteral {
+fn parse_literal_expression(token_iter: &mut Peekable<Iter<Token>>) -> NodeExpr {
     let token = token_iter.next().unwrap();
-    if token.token_type != TokenType::IntLit {
-        panic!("{}", panic_str(token, TokenType::IntLit));
+    match token.token_type {
+        TokenType::IntLit => NodeExpr::Literal(NodeLiteral::IntLit(token.value.parse().unwrap())),
+        _ => panic!(
+            "Expected an integer literal, got {:?} instead.",
+            token.token_type
+        ),
     }
-    NodeLiteral::new(token.value.clone())
 }
 
-fn parse_symbol(token_iter: &mut Peekable<Iter<Token>>, token_type: TokenType) {
-    let token = token_iter.peek().unwrap();
-    if token.token_type != token_type {
-        panic!("{}", panic_str(token, token_type));
-    }
-    token_iter.next();
-}
-
-fn panic_str(token: &Token, expected: TokenType) -> String {
-    let mut err_str = String::from("Error: Unexpected token.\n");
-    err_str.push_str(format!("\tLine: {}, Col: {}\n", token.line, token.column).as_str());
-    err_str.push_str(format!("\tExpected: {:?}, Found: {:?}", expected, token.token_type).as_str());
-    err_str
+fn parse_ident_expression(token_iter: &mut Peekable<Iter<Token>>) -> NodeExpr {
+    let ident = parse_ident(token_iter);
+    NodeExpr::Ident(ident)
 }


### PR DESCRIPTION
- I rewrote the parser and ast to properly use rust's enums and match statements, as I had completely misunderstood them before, but I think I know what they do and how to use them now.
- Additionally, I think I made a more logical `NodeType` struct that I can use later down the line. 🤞 